### PR TITLE
Add recipe for md5deep package

### DIFF
--- a/meta/recipes-extended/md5deep/files/wrong-variable-expansion.patch
+++ b/meta/recipes-extended/md5deep/files/wrong-variable-expansion.patch
@@ -1,0 +1,39 @@
+--- a/configure.ac	2014-08-22 12:22:54.290884351 +0200
++++ b/configure.ac	2014-08-22 12:23:15.822306295 +0200
+@@ -42,18 +42,6 @@
+      ;;		 		     
+ esac
+ 
+-
+-# Bring additional directories where things might be found into our
+-# search path. I don't know why autoconf doesn't do this by default
+-if test x"${mingw}" == "xno" ; then
+-  for spfx in /usr/local /opt/local /sw ; do
+-    echo checking ${spfx}/include
+-    if test -d ${spfx}/include; then
+-        CPPFLAGS="-I${spfx}/include $CPPFLAGS"
+-        LDFLAGS="-L${spfx}/lib $LDFLAGS"
+-    fi
+-  done
+-fi
+ #
+ #
+ ################################################################
+@@ -71,7 +59,7 @@
+ 
+ if test $mingw = "no" ; then
+   # add the warnings we don't want to do on mingw
+-  $WARNINGS_TO_TEST="$WARNINGS_TO_TEST -Wall -Wstrict-prototypes  -Weffc++"
++  WARNINGS_TO_TEST="$WARNINGS_TO_TEST -Wall -Wstrict-prototypes  -Weffc++"
+ fi
+ 
+ for option in $WARNINGS_TO_TEST
+@@ -105,7 +93,7 @@
+ 
+ if test $mingw = "no" ; then
+   # add the warnings we don't want to do on mingw
+-  $WARNINGS_TO_TEST="$WARNINGS_TO_TEST  -Weffc++"
++  WARNINGS_TO_TEST="$WARNINGS_TO_TEST  -Weffc++"
+ fi
+ 
+ for option in $WARNINGS_TO_TEST

--- a/meta/recipes-extended/md5deep/md5deep_4.4.bb
+++ b/meta/recipes-extended/md5deep/md5deep_4.4.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "md5deep"
+AUTHOR = "Jesse Kornblum, Simson L. Garfinkel"
+HOMEPAGE = "http://md5deep.sourceforge.net"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=9190f660105b9a56cdb272309bfd5491"
+
+inherit autotools
+
+SRC_URI = "git://github.com/jessek/hashdeep.git \
+        file://wrong-variable-expansion.patch \
+        "
+
+# Release 4.4
+SRCREV = "cd2ed7416685a5e83eb10bb659d6e9bec01244ae"
+
+S = "${WORKDIR}/git"


### PR DESCRIPTION
This recipe enables building md5deep package for OE.
We are using hashdeep to audit filesystem changes and think it is a very good tool.
I needed to remove the section with the additional directories from configure.ac because of cross-compile errors seen in configure_qa.
