### PR TITLE
Fix DTC URI

### DIFF
--- a/meta/recipes-kernel/dtc/dtc.inc
+++ b/meta/recipes-kernel/dtc/dtc.inc
@@ -6,7 +6,7 @@ DEPENDS = "flex-native bison-native"
 
 inherit autotools-brokensep
 
-SRC_URI = "git://www.jdl.com/software/dtc.git \
+SRC_URI = "git://git.kernel.org/pub/scm/utils/dtc/dtc.git \
            file://make_install.patch \
 	  "
 


### PR DESCRIPTION
#4 Modify dtc SRC_URI to refer to Linux kernel site.
