### PR TITLE
updated kernel.bbclass renamed deploy function

### DIFF
--- a/meta/classes/kernel.bbclass
+++ b/meta/classes/kernel.bbclass
@@ -450,7 +450,7 @@ MODULE_TARBALL_BASE_NAME ?= "${MODULE_IMAGE_BASE_NAME}.tgz"
 MODULE_TARBALL_SYMLINK_NAME ?= "modules-${MACHINE}.tgz"
 MODULE_TARBALL_DEPLOY ?= "1"
 
-kernel_do_deploy() {
+do_deploy() {
 	install -m 0644 ${KERNEL_OUTPUT} ${DEPLOYDIR}/${KERNEL_IMAGE_BASE_NAME}.bin
 	if [ ${MODULE_TARBALL_DEPLOY} = "1" ] && (grep -q -i -e '^CONFIG_MODULES=y$' .config); then
 		mkdir -p ${D}/lib


### PR DESCRIPTION
renamed kernel_do_deploy function after broken build.
kernel recipe which inherits kernel.bbclass cannot finish deploy phase as long as the function was called kernel_do_deploy
deploy phase aborts cause command do_deploy was not found.