### PR TITLE
tzdata: update to 2016d

### DIFF
--- a/meta/recipes-extended/tzdata/tzdata_2016e.bb
+++ b/meta/recipes-extended/tzdata/tzdata_2016e.bb
@@ -8,8 +8,8 @@ DEPENDS = "tzcode-native"
 
 SRC_URI = "http://www.iana.org/time-zones/repository/releases/tzdata${PV}.tar.gz;name=tzdata"
 
-SRC_URI[tzdata.md5sum] = "14bf84b6c2cdab0a9428991e0150ebe6"
-SRC_URI[tzdata.sha256sum] = "d9554dfba0efd76053582bd89e8c7036ef12eee14fdd506675b08a5b59f0a1b4"
+SRC_URI[tzdata.md5sum] = "43f9f929a8baf0dd2f17efaea02c2d2a"
+SRC_URI[tzdata.sha256sum] = "ba00f899f18dc4048d7fa21f5e1fdef434496084eedc06f6caa15e5ecdb6bd81"
 
 inherit allarch
 


### PR DESCRIPTION
  Changes affecting future time stamps

    Africa/Cairo observes DST in 2016 from July 7 to the end of October.
    Guess October 27 and 24:00 transitions. (Thanks to Steffen Thorsen.)
    For future years, guess April's last Thursday to October's last
    Thursday except for Ramadan.

  Changes affecting past time stamps

    Locations while uninhabited now use '-00', not 'zzz', as a
    placeholder time zone abbreviation.  This is inspired by Internet
    RFC 3339 and is more consistent with numeric time zone
    abbreviations already used elsewhere.  The change affects several
    arctic and antarctic locations, e.g., America/Cambridge_Bay before
    1920 and Antarctica/Troll before 2005.

    Asia/Baku's 1992-09-27 transition from +04 (DST) to +04 (non-DST) was
    at 03:00, not 23:00 the previous day.  (Thanks to Michael Deckers.)