### PR TITLE
initramfs-live-install: Add aarch64 arch to COMPATIBLE_HOST.

### DIFF
--- a/meta/recipes-core/initrdscripts/initramfs-live-install-efi_1.0.bb
+++ b/meta/recipes-core/initrdscripts/initramfs-live-install-efi_1.0.bb
@@ -21,4 +21,4 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 FILES_${PN} = " /install-efi.sh "
 
-COMPATIBLE_HOST = "(i.86|x86_64).*-linux"
+COMPATIBLE_HOST = "(i.86.*|x86_64.*|aarch64.*)-linux"

--- a/meta/recipes-core/initrdscripts/initramfs-live-install_1.0.bb
+++ b/meta/recipes-core/initrdscripts/initramfs-live-install_1.0.bb
@@ -21,4 +21,4 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 FILES_${PN} = " /install.sh "
 
-COMPATIBLE_HOST = "(i.86|x86_64).*-linux"
+COMPATIBLE_HOST = "(i.86.*|x86_64.*|aarch64.*)-linux"


### PR DESCRIPTION
Signed-off-by: Peter Griffin <peter.griffin@linaro.org>