### PR TITLE
revert use of filter

### DIFF
--- a/meta/recipes-core/dropbear/dropbear.inc
+++ b/meta/recipes-core/dropbear/dropbear.inc
@@ -74,7 +74,7 @@ do_install() {
 		-e 's,/usr/bin,${bindir},g' \
 		-e 's,/usr,${prefix},g' ${WORKDIR}/init > ${D}${sysconfdir}/init.d/dropbear
 	chmod 755 ${D}${sysconfdir}/init.d/dropbear
-	if [ "${@bb.utils.filter('DISTRO_FEATURES', 'pam', d)}" ]; then
+        if [ "${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'pam', '', d)}" = "pam" ]; then
 		install -d ${D}${sysconfdir}/pam.d
 		install -m 0644 ${WORKDIR}/dropbear  ${D}${sysconfdir}/pam.d/
 	fi


### PR DESCRIPTION
using filter prevents this recipe to be used with older version of bitbake.
@saur2000 Please revert to the older test for pam support.

e.g. openvuplus_3.0 is harder to update to use a current version of dropbear because of this change.
if openvuplus_3.0 would update to a new version of bitbake other things break.
I do not know what breaks if openvuplus_3.0 would update to a newer version of openembedded, but I guess that break other things.

Currently vuplus uses a vulnerable version of dropbear. Not updating it is a security issue.
Which is not really your problem but with this change reverted this recipe can simply be a drop-in replacement for the old dropbear.

Thank you
Axel