### PR TITLE
Update create_npm.py: Prevent NameError

### DIFF
--- a/scripts/lib/recipetool/create_npm.py
+++ b/scripts/lib/recipetool/create_npm.py
@@ -320,6 +320,7 @@ class NpmRecipeHandler(RecipeHandler):
                     blacklist = True
                     break
             if (not blacklist and 'linux' not in pkg_os) or '!linux' in pkg_os:
+                pkg = pdata.get('name', None)
                 logger.debug(2, "Skipping %s since it's incompatible with Linux" % pkg)
                 return False
         return True


### PR DESCRIPTION
`NameError` is currently thrown if an optional npm dependency does not support Linux.