### PR TITLE
DNS Failed to start Berkeley Internet Name Domain

### DIFF
--- a/meta/recipes-connectivity/bind/bind/conf.patch
+++ b/meta/recipes-connectivity/bind/bind/conf.patch
@@ -277,7 +277,7 @@ diff -urN bind-9.3.1.orig/init.d bind-9.3.1/init.d
 +	modprobe capability >/dev/null 2>&1 || true
 +	if [ ! -f /etc/bind/rndc.key ]; then
 +	    /usr/sbin/rndc-confgen -a -b 512 -r /dev/urandom
-+	    chmod 0640 /etc/bind/rndc.key
++	    chmod 0644 /etc/bind/rndc.key
 +	fi
 +	if [ -f /var/run/named/named.pid ]; then
 +	    ps `cat /var/run/named/named.pid` > /dev/null && exit 1


### PR DESCRIPTION
Please review and merge rndc.key permissions change to resolve DNS issue on booting screen.
@rossburton  
@rpurdie
@kergoth
@kraj 


May 09 18:00:20 named[460]: loading configuration from '/etc/bind/named.conf'
May 09 18:00:20 named[460]: [[0;1;31m/etc/bind/named.conf:50: open: /etc/bind/rndc.key: permission denied[[0m
May 09 18:00:20 named[460]: [[0;1;31mloading configuration: permission denied[[0m
May 09 18:00:20 named[460]: [[0;1;31mexiting (due to fatal error)[[0m
May 09 18:00:20 systemd[1]: [[0;1;39mnamed.service: Control process exited, code=exited status=1[[0m
May 09 18:00:20 systemd[1]: [[0;1;31mFailed to start Berkeley Internet Name Domain (DNS).[[0m