### PR TITLE
nativesdk-packagegroup-sdk-host: Add wayland-scanner to the SDK native toolchain

### DIFF
--- a/meta/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bb
+++ b/meta/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bb
@@ -23,7 +23,7 @@ RDEPENDS_${PN} = "\
     nativesdk-makedevs \
     nativesdk-dnf \
     nativesdk-cmake \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'nativesdk-wayland', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'nativesdk-wayland-dev', '', d)} \
     nativesdk-sdk-provides-dummy \
     "
 


### PR DESCRIPTION
The wayland-scanner was missing from the native toolchain for SDK build
because wayland dev package only copy the wayland-scanner.