### PR TITLE
Change libsdl2 SRC_URI prefix from http to https

### DIFF
--- a/meta/recipes-graphics/libsdl2/libsdl2_2.0.8.bb
+++ b/meta/recipes-graphics/libsdl2/libsdl2_2.0.8.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://COPYING.txt;md5=02ee26814dd044bd7838ae24e05b880f"
 
 PROVIDES = "virtual/libsdl2"
 
-SRC_URI = "http://www.libsdl.org/release/SDL2-${PV}.tar.gz \
+SRC_URI = "https://www.libsdl.org/release/SDL2-${PV}.tar.gz \
            file://more-gen-depends.patch \
            file://0001-GLES2-Get-sin-cos-out-of-vertex-shader.patch \
 "


### PR DESCRIPTION
Fetching libsdl2 (and libsdl) has been failing intermittently (behind my company's restrictive HTTP proxy) with the error: "503 Service Unavailable", even though an HSTS policy is supposed to be in place to switch to HTTPS automatically.  Changing the recipes to use `https` sidesteps the problem entirely, so I'm hopeful that this will be accepted upstream to help other people suffering from this minor annoyance.