### PR TITLE
Change libsdl SRC_URI prefix from http to https

### DIFF
--- a/meta/recipes-graphics/libsdl/libsdl_1.2.15.bb
+++ b/meta/recipes-graphics/libsdl/libsdl_1.2.15.bb
@@ -14,7 +14,7 @@ PROVIDES = "virtual/libsdl"
 
 PR = "r3"
 
-SRC_URI = "http://www.libsdl.org/release/SDL-${PV}.tar.gz \
+SRC_URI = "https://www.libsdl.org/release/SDL-${PV}.tar.gz \
            file://libsdl-1.2.15-xdata32.patch \
            file://pkgconfig.patch \
            file://0001-build-Pass-tag-CC-explictly-when-using-libtool.patch \


### PR DESCRIPTION
Fetching libsdl (and libsdl2) has been failing intermittently (behind my company's restrictive HTTP proxy) with the error: "503 Service Unavailable", even though an HSTS policy is supposed to be in place to switch to HTTPS automatically.  Changing the recipes to use `https` sidesteps the problem entirely, so I'm hopeful that this will be accepted upstream to help other people suffering from this minor annoyance.