### PR TITLE
limit palallel make with load average

### DIFF
--- a/meta/conf/bitbake.conf
+++ b/meta/conf/bitbake.conf
@@ -789,7 +789,7 @@ CACHE := "${CACHE}"
 BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
 
 # Default to setting automatically based on cpu count
-PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
+PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()} -l ${@oe.utils.cpu_count()}"
 
 ##################################################################
 # Magic Cookie for SANITY CHECK


### PR DESCRIPTION
Unlimited recursive and multiple parallel makes run much more tasks than CPUs, overloads system and dramatically increases load average. 
Option --load-average[=load]  specifies that no new jobs should be started if there are others jobs running and the load average is at least as specified.