### PR TITLE
gdb-cross-canadian: Add bison-native for gdb-cross-canadian

### DIFF
--- a/meta/recipes-devtools/gdb/gdb-cross-canadian.inc
+++ b/meta/recipes-devtools/gdb/gdb-cross-canadian.inc
@@ -5,7 +5,7 @@ SUMMARY = "GNU debugger (cross-canadian gdb for ${TARGET_ARCH} target)"
 PN = "gdb-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 BPN = "gdb"
 
-DEPENDS = "nativesdk-ncurses nativesdk-expat nativesdk-gettext \
+DEPENDS = "nativesdk-ncurses nativesdk-expat nativesdk-gettext bison-native \
            virtual/${HOST_PREFIX}gcc-crosssdk virtual/${HOST_PREFIX}binutils-crosssdk virtual/nativesdk-${HOST_PREFIX}libc-for-gcc"
 
 GDBPROPREFIX = "--program-prefix='${TARGET_PREFIX}'"


### PR DESCRIPTION
Got errors when build SDK. Unable to find bison.
To fix this issue add bison-native.

Signed-off-by: pino-kim <sungwon.pino@gmail.com>