### PR TITLE
Make prune_suffix prune a suffix

### DIFF
--- a/meta/lib/oe/utils.py
+++ b/meta/lib/oe/utils.py
@@ -78,12 +78,12 @@ def prune_suffix(var, suffixes, d):
     # See if var ends with any of the suffixes listed and
     # remove it if found
     for suffix in suffixes:
-        if var.endswith(suffix):
-            var = var.replace(suffix, "")
+        if suffix and var.endswith(suffix):
+            var = var[:-len(suffix)]
 
     prefix = d.getVar("MLPREFIX")
     if prefix and var.startswith(prefix):
-        var = var.replace(prefix, "")
+        var = var[len(prefix):]
 
     return var
 


### PR DESCRIPTION
... instead of replacing a substring that could happen more than once
and not only when it ends with it. Do the same for the prefix.

See related https://github.com/openembedded/bitbake/pull/24 . There it
stops replacing sufixes once first one is matched but not here.

Signed-off-by: Andre Rosa <andre.rosa@lge.com>