### PR TITLE
uboot-sign: Fix u-boot-nodtb symlinks

### DIFF
--- a/meta/classes/uboot-sign.bbclass
+++ b/meta/classes/uboot-sign.bbclass
@@ -53,8 +53,8 @@ concat_dtb_helper() {
 
 	if [ -f "${UBOOT_NODTB_BINARY}" ]; then
 		install ${UBOOT_NODTB_BINARY} ${DEPLOYDIR}/${UBOOT_NODTB_IMAGE}
-		ln -sf ${UBOOT_NODTB_IMAGE} ${UBOOT_NODTB_SYMLINK}
-		ln -sf ${UBOOT_NODTB_IMAGE} ${UBOOT_NODTB_BINARY}
+		ln -sf ${UBOOT_NODTB_IMAGE} ${DEPLOYDIR}/${UBOOT_NODTB_SYMLINK}
+		ln -sf ${UBOOT_NODTB_IMAGE} ${DEPLOYDIR}/${UBOOT_NODTB_BINARY}
 	fi
 
 	# Concatenate U-Boot w/o DTB & DTB with public key


### PR DESCRIPTION
When using u-boot-nodtb, the symlink didn't install correctly to the
${DEPLOYDIR}. This commit fixes this bug.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>