### PR TITLE
Assert error when there are multiple shlib_providers for the same file

### DIFF
--- a/meta/classes/package.bbclass
+++ b/meta/classes/package.bbclass
@@ -1580,6 +1580,7 @@ SHLIBSDIRS = "${WORKDIR_PKGDATA}/${MLPREFIX}shlibs2"
 SHLIBSWORKDIR = "${PKGDESTWORK}/${MLPREFIX}shlibs2"
 
 python package_do_shlibs() {
+    import itertools
     import re, pipes
     import subprocess
 
@@ -1835,16 +1836,16 @@ python package_do_shlibs() {
                 bb.debug(2, '%s: Dependency %s covered by PRIVATE_LIBS' % (pkg, n[0]))
                 continue
             if n[0] in shlib_provider.keys():
-                shlib_provider_path = []
-                for k in shlib_provider[n[0]].keys():
-                    shlib_provider_path.append(k)
-                match = None
-                for p in list(n[2]) + shlib_provider_path + libsearchpath:
-                    if p in shlib_provider[n[0]]:
-                        match = p
-                        break
-                if match:
-                    (dep_pkg, ver_needed) = shlib_provider[n[0]][match]
+                shlib_provider_map = shlib_provider[n[0]]
+                matches = set()
+                for p in itertools.chain(list(n[2]), shlib_provider_map.keys(), libsearchpath):
+                    if p in shlib_provider_map:
+                        matches.add(p)
+                if len(matches) > 1:
+                    matchpkgs = ', '.join([shlib_provider_map[match][0] for match in matches])
+                    bb.fatal("%s: Multiple shlib providers for %s: %s (used by files: %s)" % (pkg, n[0], matchpkgs, n[1]))
+                elif len(matches) == 1:
+                    (dep_pkg, ver_needed) = shlib_provider_map[matches.pop()]
 
                     bb.debug(2, '%s: Dependency %s requires package %s (used by files: %s)' % (pkg, n[0], dep_pkg, n[1]))
 


### PR DESCRIPTION
I know this isn't the way to submit patches I'm currently having a hard time figuring out how to configure `git send-email` to go through a proxy.  I can fetch/push changes to repositories via any protocol on any port, but `git send-email` seems to ignore the proxy settings.  It seems like `git send-email` doesn't support proxies so I'm not sure what to do here.

### Commit Description

In the case where multiple packages provide the same file, we want to assert an error.  Otherwise, python will generate a different build depending on which provider appears first in the dictionary.  On my system this order changes every time I run bitbake causing different runtime dependencies every time I run the build.