### PR TITLE
libdnf: support for removing libcheck dependencies

### DIFF
--- a/meta/classes/siteinfo.bbclass
+++ b/meta/classes/siteinfo.bbclass
@@ -18,8 +18,8 @@
 def siteinfo_data_for_machine(arch, os, d):
     archinfo = {
         "allarch": "endian-little bit-32", # bogus, but better than special-casing the checks below for allarch
-        "aarch64": "endian-little bit-64 arm-common arm-64",
-        "aarch64_be": "endian-big bit-64 arm-common arm-64",
+        "aarch64": "endian-little bit-64 arm-common",
+        "aarch64_be": "endian-big bit-64 arm-common",
         "arc": "endian-little bit-32 arc-common",
         "arceb": "endian-big bit-32 arc-common",
         "arm": "endian-little bit-32 arm-common arm-32",
@@ -78,9 +78,9 @@ def siteinfo_data_for_machine(arch, os, d):
         "mingw32": "common-mingw",
     }
     targetinfo = {
-        "aarch64-linux-gnu": "aarch64-linux",
-        "aarch64_be-linux-gnu": "aarch64_be-linux",
-        "aarch64-linux-gnu_ilp32": "bit-32 aarch64_be-linux arm-32",
+        "aarch64-linux-gnu": "aarch64-linux arm-64",
+        "aarch64_be-linux-gnu": "aarch64_be-linux arm-64",
+        "aarch64-linux-gnu_ilp32": "bit-32 aarch64-linux arm-32",
         "aarch64_be-linux-gnu_ilp32": "bit-32 aarch64_be-linux arm-32",
         "aarch64-linux-musl": "aarch64-linux",
         "aarch64_be-linux-musl": "aarch64_be-linux",

--- a/meta/recipes-devtools/libdnf/libdnf/0001-libdnf-support-for-removing-libcheck-dependencies.patch
+++ b/meta/recipes-devtools/libdnf/libdnf/0001-libdnf-support-for-removing-libcheck-dependencies.patch
@@ -1,0 +1,26 @@
+From 5fadf5e07efcb30d9ea2bbeab6f2c92be441591d Mon Sep 17 00:00:00 2001
+From: Yanlin Du <duyanlin@huawei.com>
+Date: Thu, 19 Sep 2019 10:51:58 +0800
+Subject: [PATCH] libdnf: support for removing libcheck dependencies
+
+libcheck could be removed, when WITH_TESTS is turned on.
+
+Signed-off-by: Yanlin Du <duyanlin@huawei.com>
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6df91e1..8c05eed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,7 +51,9 @@ find_package(OpenSSL REQUIRED)
+ 
+ 
+ # build dependencies via pkg-config
++IF (WITH_TESTS)
+ pkg_check_modules(CHECK REQUIRED check)
++ENDIF()
+ pkg_check_modules(GLIB REQUIRED gio-unix-2.0>=2.46.0)
+ include_directories(${GLIB_INCLUDE_DIRS})
+ pkg_check_modules(JSONC REQUIRED json-c)
+-- 
+1.8.5.6
+


### PR DESCRIPTION
libcheck could be removed, when WITH_TESTS is turned on.

Signed-off-by: Yanlin Du <duyanlin@huawei.com>