### PR TITLE
Cleaning up warnings when building fitimages.

### DIFF
--- a/meta/classes/kernel-fitimage.bbclass
+++ b/meta/classes/kernel-fitimage.bbclass
@@ -19,9 +19,9 @@ python __anonymous () {
         else:
             replacementtype = "zImage"
 
-	# Override KERNEL_IMAGETYPE_FOR_MAKE variable, which is internal
-	# to kernel.bbclass . We have to override it, since we pack zImage
-	# (at least for now) into the fitImage .
+        # Override KERNEL_IMAGETYPE_FOR_MAKE variable, which is internal
+        # to kernel.bbclass . We have to override it, since we pack zImage
+        # (at least for now) into the fitImage .
         typeformake = d.getVar("KERNEL_IMAGETYPE_FOR_MAKE") or ""
         if 'fitImage' in typeformake.split():
             d.setVar('KERNEL_IMAGETYPE_FOR_MAKE', typeformake.replace('fitImage', replacementtype))


### PR DESCRIPTION
When building images that use the kernel-fitimage warnings like the following are reported.
This change removes these warnings from the builds
WARNING: /home/user/dev/meta-pine64/recipes-kernel/linux/linux-mainline_5.2.bb: python should use 4 spaces indentation, but found tabs in kernel-fitimage.bbclass, line 22
WARNING: /home/user/dev/meta-pine64/recipes-kernel/linux/linux-mainline_5.2.bb: python should use 4 spaces indentation, but found tabs in kernel-fitimage.bbclass, line 23
WARNING: /home/user/dev/meta-pine64/recipes-kernel/linux/linux-mainline_5.2.bb: python should use 4 spaces indentation, but found tabs in kernel-fitimage.bbclass, line 24