### PR TITLE
lighttpd: make sure /var/tmp and /var/log exist

### DIFF
--- a/meta/recipes-extended/lighttpd/lighttpd_1.4.54.bb
+++ b/meta/recipes-extended/lighttpd/lighttpd_1.4.54.bb
@@ -67,6 +67,7 @@ do_install_append() {
 		-e 's,@BASE_BINDIR@,${base_bindir},g' \
 		${D}${systemd_unitdir}/system/lighttpd.service
 	#For FHS compliance, create symbolic links to /var/log and /var/tmp for logs and temporary data
+	install -d ${D}${localstatedir}/log ${D}${localstatedir}/tmp
 	ln -sf ${localstatedir}/log ${D}/www/logs
 	ln -sf ${localstatedir}/tmp ${D}/www/var
 }


### PR DESCRIPTION
The install of lighttpd links /www/logs and /www/tmp to /var/log and /var/tmp
but those directories do not necessarily exist.

Signed-off-by: Louis Rannou <louis.rannou@smile.fr>