### PR TITLE
libva: Removed virtual/mesa dependency

### DIFF
--- a/meta/recipes-graphics/libva/libva_2.6.1.bb
+++ b/meta/recipes-graphics/libva/libva_2.6.1.bb
@@ -23,7 +23,7 @@ SRC_URI[sha256sum] = "6c57eb642d828af2411aa38f55dc10111e8c98976dbab8fd62e4862940
 
 UPSTREAM_CHECK_URI = "https://github.com/intel/libva/releases"
 
-DEPENDS = "libdrm virtual/mesa"
+DEPENDS = "libdrm"
 
 inherit meson pkgconfig features_check
 


### PR DESCRIPTION
Mesa can be compiled with libva support, in order to avoid recursive
dependency between mesa and libva, virtual/mesa must be removed
from libva recipe.

Signed-off-by: Bartłomiej Burdukiewicz <bartlomiej.burdukiewicz@gmail.com>

There is append that created for meta-kodi, that is extending mesa with libva and libvdpau capabilities:
https://github.com/dev-0x7C6/meta-kodi/blob/zeus/recipes-graphics/mesa/mesa_%25.bbappend

And this is current workaround for libva: 
https://github.com/dev-0x7C6/meta-kodi/blob/zeus/recipes-graphics/libva/libva_%25.bbappend

