### PR TITLE
groff: prefer strsignal over sys_siglist

### DIFF
--- a/meta/recipes-extended/groff/files/prefer_strsignal_over_sys_siglist.patch
+++ b/meta/recipes-extended/groff/files/prefer_strsignal_over_sys_siglist.patch
@@ -1,0 +1,30 @@
+diff -ur groff-1.22.4ori/configure.ac groff-1.22.4/configure.ac
+--- groff-1.22.4ori/configure.ac	2018-12-18 22:13:01.000000000 +0100
++++ groff-1.22.4/configure.ac	2021-01-06 12:39:16.000000000 +0100
+@@ -140,6 +140,7 @@
+ LIBS="$saved_libs"
+ AC_CHECK_FUNCS([gettimeofday isatty kill rename setlocale strsep])
+ GROFF_MKSTEMP
++AC_CHECK_DECLS([strsignal, getc_unlocked])
+ AC_CHECK_DECLS([sys_siglist, getc_unlocked])
+ AM_LANGINFO_CODESET
+ 
+diff -ur groff-1.22.4ori/src/roff/groff/pipeline.c groff-1.22.4/src/roff/groff/pipeline.c
+--- groff-1.22.4ori/src/roff/groff/pipeline.c	2018-10-10 23:44:56.000000000 +0200
++++ groff-1.22.4/src/roff/groff/pipeline.c	2021-01-06 12:41:58.000000000 +0100
+@@ -570,10 +570,15 @@
+   static char buf[sizeof("Signal ") + 1 + sizeof(int) * 3];
+ 
+ #ifdef NSIG
++#if HAVE_DECL_STRSIGNAL
++  if (n >= 0 && n < NSIG && strsignal(n) != 0)
++    return strsignal(n);
++#else
+ #if HAVE_DECL_SYS_SIGLIST
+   if (n >= 0 && n < NSIG && sys_siglist[n] != 0)
+     return sys_siglist[n];
+ #endif /* HAVE_DECL_SYS_SIGLIST */
++#endif /* HAVE_DECL_STRSIGNAL */
+ #endif /* NSIG */
+   sprintf(buf, "Signal %d", n);
+   return buf;

--- a/meta/recipes-extended/groff/groff_1.22.4.bb
+++ b/meta/recipes-extended/groff/groff_1.22.4.bb
@@ -13,6 +13,7 @@ SRC_URI = "${GNU_MIRROR}/groff/groff-${PV}.tar.gz \
 	file://0001-support-musl.patch \
 	file://0001-Include-config.h.patch \
         file://0001-Make-manpages-mulitlib-identical.patch \
+	file://prefer_strsignal_over_sys_siglist.patch \
 "
 
 SRC_URI[md5sum] = "08fb04335e2f5e73f23ea4c3adbf0c5f"


### PR DESCRIPTION
I got for build openbh an undeclared sys_siglist, but autoconf still found it. I updated binutil to 2.35 that the missing string.h include is inside, maybe is that the root cause.