### PR TITLE
Fix Systemtap Install Recipe Error

### DIFF
--- a/meta/recipes-kernel/systemtap/systemtap_git.bb
+++ b/meta/recipes-kernel/systemtap/systemtap_git.bb
@@ -51,13 +51,18 @@ do_install_append () {
       rm ${D}${libexecdir}/${PN}/stap-env
    fi
 
-   # Fix makefile hardcoded path assumptions for systemd (assumes $prefix)
-   install -d `dirname ${D}${systemd_unitdir}`
-   mv ${D}${prefix}/lib/systemd `dirname ${D}${systemd_unitdir}`
-   rmdir ${D}${prefix}/lib --ignore-fail-on-non-empty
+   if [ -d ${D}${prefix}/lib/systemd -a ${D}${prefix}/lib != `dirname ${D}${systemd_unitdir}` ]; then
+      # Fix makefile hardcoded path assumptions for systemd (assumes $prefix)
+      # without usrmerge distro feature enabled
+      install -d `dirname ${D}${systemd_unitdir}`
+      mv ${D}${prefix}/lib/systemd `dirname ${D}${systemd_unitdir}`
+      rmdir ${D}${prefix}/lib --ignore-fail-on-non-empty
+   fi
 
    # Ensure correct ownership for files copied in
-   chown root:root ${D}${sysconfdir}/stap-exporter/* -R
+   if [ -d ${D}${sysconfdir}/stap-exporter ]; then
+      chown root:root ${D}${sysconfdir}/stap-exporter/* -R
+   fi
 }
 
 BBCLASSEXTEND = "nativesdk"


### PR DESCRIPTION
During SDK installation the following error is received,

```bash
ERROR: Task (/home/kwalsh/workspace/images/hawkeye_1.0.1/sources/poky/meta/recipes-kernel/systemtap/systemtap_git.bb:do_install) failed with exit code '1'
```

The log file indicates,

```bash
mv: '/.../tmp/work/corei7-64-poky-linux/systemtap/4.0-r0/image/usr/lib/systemd' and '/.../tmp/work/corei7-64-poky-linux/systemtap/4.0-r0/image/usr/lib/systemd' are the same file
```

Pull request mirrors `master` branch for the same recipe, once implemented install works perfectly.