### PR TITLE
strace 5.13 -> strace 5.14

### DIFF
--- a/meta/recipes-devtools/strace/strace_5.14.bb
+++ b/meta/recipes-devtools/strace/strace_5.14.bb
@@ -15,7 +15,7 @@ SRC_URI = "https://strace.io/files/${PV}/strace-${PV}.tar.xz \
            file://uintptr_t.patch \
            file://0001-strace-fix-reproducibilty-issues.patch \
            "
-SRC_URI[sha256sum] = "5acc34888b9d510ad6ac915d4a8df08f51cf1ae920ea24649f6a4bb984d0b656"
+SRC_URI[sha256sum] = "901bee6db5e17debad4530dd9ffb4dc9a96c4a656edbe1c3141b7cb307b11e73"
 
 inherit autotools ptest
 


### PR DESCRIPTION
Strace 5.13 won't compile with 5.14 headers:

| ../../strace-5.13/src/fs_x_ioctl.c: In function 'fs_x_ioctl':
| ../../strace-5.13/src/fs_x_ioctl.c:64:14: error: invalid application of 'sizeof' to incomplete type 'struct fsxattr'
|    64 |         case FS_IOC_FSGETXATTR:
|       |              ^~~~~~~~~~~~~~~~~
| ../../strace-5.13/src/fs_x_ioctl.c:71:14: error: invalid application of 'sizeof' to incomplete type 'struct fsxattr'
|    71 |         case FS_IOC_FSSETXATTR:
|       |              ^~~~~~~~~~~~~~~~~
| make[3]: *** [Makefile:5011: libstrace_a-fs_x_ioctl.o] Error 1
| make[3]: *** Waiting for unfinished jobs....

According to https://strace.io/files/5.14/:

* Improvements
  * Implemented decoding of memfd_secret and quotactl_fd syscalls,
    introduced in Linux 5.14.
  * Enhanced prctl syscall decoding.
  * Enhanced decoding of IFLA_* netlink attributes.
  * Enhanced decoding of MDBA_ROUTER_PATTR_* mdb router port netlink attributes.
  * Updated lists of BPF_*, IORING_*, MADV_*, MOUNT_ATTR_*, SCTP_*,
    and UFFD_* constants.
  * Updated lists of ioctl commands from Linux 5.14.