### PR TITLE
rust-target-config.bbclass: +v7 implies +neon

### DIFF
--- a/meta/classes-recipe/rust-target-config.bbclass
+++ b/meta/classes-recipe/rust-target-config.bbclass
@@ -29,9 +29,6 @@ def llvm_features_from_tune(d):
     if 'vfpv2' in feat or 'vfp' in feat:
         f.append("+vfp2")
 
-    if 'neon' in feat:
-        f.append("+neon")
-
     if 'mips32' in feat:
         f.append("+mips32")
 
@@ -40,6 +37,11 @@ def llvm_features_from_tune(d):
 
     if target_is_armv7(d):
         f.append('+v7')
+
+    if 'neon' in feat:
+        f.append("+neon")
+    else:
+        f.append("-neon")
 
     if ('armv6' in mach_overrides) or ('armv6' in feat):
         f.append("+v6")


### PR DESCRIPTION
If we don't support neon, then (at least on armv7) we must explicitly throw -neon.  Additionally, this must occur after the "+v7" to have an effect.