### PR TITLE
git-intercept does not exist

### DIFF
--- a/meta/classes/devshell.bbclass
+++ b/meta/classes/devshell.bbclass
@@ -2,7 +2,7 @@ inherit terminal
 
 DEVSHELL = "${SHELL}"
 
-PATH:prepend:task-devshell = "${COREBASE}/scripts/git-intercept:"
+PATH:prepend:task-devshell = "${COREBASE}/scripts/git:"
 
 python do_devshell () {
     if d.getVarFlag("do_devshell", "manualfakeroot"):


### PR DESCRIPTION
In this commit - ce6e606ba8b975a33df2f3dc6104abed9cfa7a36 (patch), git-intercept was renamed to git. 
devshell.bbclass is still referring to git-intercept, causing builds to fail.
https://git.openembedded.org/openembedded-core/commit/scripts?h=dunfell&id=ce6e606ba8b975a33df2f3dc6104abed9cfa7a36







