### PR TITLE
run-postinsts: Set dependency for ldconfig to avoid boot issues

### DIFF
--- a/meta/recipes-devtools/run-postinsts/run-postinsts/run-postinsts.service
+++ b/meta/recipes-devtools/run-postinsts/run-postinsts/run-postinsts.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Run pending postinsts
 DefaultDependencies=no
-After=systemd-remount-fs.service systemd-tmpfiles-setup.service tmp.mount
+After=systemd-remount-fs.service systemd-tmpfiles-setup.service tmp.mount ldconfig.service
 Before=sysinit.target
 
 [Service]


### PR DESCRIPTION
If a package with a postsints script requires ldconfig, the package class adds a ldconfig postinst fragment to initialize it before. Systemd has its own ldconfig.service to initialize it and sometimes if both services are running at the same time in the first boot, the first one will work, but the second one will fail with the following error:

    ldconfig[141]: /sbin/ldconfig: Renaming of /etc/ld.so.cache~ to /etc/ld.so.cache failed: No such file or directory

This commit adds a ordering dependency between them to make sure that only one service is running at the same time.

Signed-off-by: Arturo Buzarra <arturo.buzarra@digi.com>