### PR TITLE
Fix externalsrc harder

### DIFF
--- a/meta/classes/externalsrc.bbclass
+++ b/meta/classes/externalsrc.bbclass
@@ -230,16 +230,18 @@ def srctree_hash_files(d, srcdir=None):
             env['GIT_INDEX_FILE'] = tmp_index.name
             subprocess.check_output(['git', 'add', '-A', '.'], cwd=s_dir, env=env)
             git_sha1 = subprocess.check_output(['git', 'write-tree'], cwd=s_dir, env=env).decode("utf-8")
-            if os.path.exists(os.path.join(s_dir, ".gitmodules")):
-                submodule_helper = subprocess.check_output(["git", "config", "--file", ".gitmodules", "--get-regexp", "path"], cwd=s_dir, env=env).decode("utf-8")
-                for line in submodule_helper.splitlines():
-                    module_dir = os.path.join(s_dir, line.rsplit(maxsplit=1)[1])
-                    if os.path.isdir(module_dir):
-                        proc = subprocess.Popen(['git', 'add', '-A', '.'], cwd=module_dir, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                        proc.communicate()
-                        proc = subprocess.Popen(['git', 'write-tree'], cwd=module_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-                        stdout, _ = proc.communicate()
-                        git_sha1 += stdout.decode("utf-8")
+            try:
+                submodule_helper = subprocess.check_output(['git', 'submodule--helper', 'list'], cwd=s_dir, env=env).decode("utf-8")
+            except subprocess.CalledProcessError:
+                submodule_helper = subprocess.check_output("git submodule--helper foreach --quiet 'echo $path'", cwd=s_dir, env=env, shell=True).decode("utf-8")
+            for line in submodule_helper.splitlines():
+                module_dir = os.path.join(s_dir, line.split()[-1])
+                if os.path.isdir(module_dir):
+                    proc = subprocess.Popen(['git', 'add', '-A', '.'], cwd=module_dir, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    proc.communicate()
+                    proc = subprocess.Popen(['git', 'write-tree'], cwd=module_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+                    stdout, _ = proc.communicate()
+                    git_sha1 += stdout.decode("utf-8")
             sha1 = hashlib.sha1(git_sha1.encode("utf-8")).hexdigest()
         with open(oe_hash_file, 'w') as fobj:
             fobj.write(sha1)

--- a/meta/classes/externalsrc.bbclass
+++ b/meta/classes/externalsrc.bbclass
@@ -234,9 +234,10 @@ def srctree_hash_files(d, srcdir=None):
                 submodule_helper = subprocess.check_output(['git', 'submodule--helper', 'list'], cwd=s_dir, env=env).decode("utf-8")
             except subprocess.CalledProcessError:
                 submodule_helper = subprocess.check_output("git submodule--helper foreach --quiet 'echo $path'", cwd=s_dir, env=env, shell=True).decode("utf-8")
+            toplevel = subprocess.check_output(['git', '-C', s_dir, 'rev-parse', '--show-toplevel'], cwd=s_dir, env=env).decode("utf-8")
             for line in submodule_helper.splitlines():
-                module_dir = os.path.join(s_dir, line.split()[-1])
-                if os.path.isdir(module_dir):
+                module_dir = os.path.join(toplevel.strip(), line.split()[-1])
+                if os.path.isdir(module_dir) and os.path.commonpath([s_dir]) == os.path.commonpath([s_dir, module_dir]):
                     proc = subprocess.Popen(['git', 'add', '-A', '.'], cwd=module_dir, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                     proc.communicate()
                     proc = subprocess.Popen(['git', 'write-tree'], cwd=module_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
Add fixes for submodule handling in `srctree_hash_files()` after upstream broken fixes when git submodule-helper list was deprecated.