### PR TITLE
package-index: Drop do_package_index[nostamp]

### DIFF
--- a/meta/recipes-core/meta/package-index.bb
+++ b/meta/recipes-core/meta/package-index.bb
@@ -15,7 +15,6 @@ deltask do_install
 deltask do_populate_lic
 deltask do_populate_sysroot
 
-do_package_index[nostamp] = "1"
 do_package_index[depends] += "${PACKAGEINDEXDEPS}"
 
 python do_package_index() {


### PR DESCRIPTION
To fix:
cd: can't cd to <root>/build/tmp/stamps/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/package-index

After removal of tmp dir.

Introduced with:
https://git.openembedded.org/bitbake/commit/?id=c79ecec580e4c2a141ae483ec0f6448f70593dcf

Signed-off-by: Hains van den Bosch <hainsvdbosch@ziggo.nl>