### PR TITLE
pango: Fix build with gcc-13

### DIFF
--- a/meta/recipes-graphics/pango/pango/0001-Drop-Werror-array-bounds.patch
+++ b/meta/recipes-graphics/pango/pango/0001-Drop-Werror-array-bounds.patch
@@ -1,0 +1,37 @@
+From e93dbd66973040f1e0afcba0dc7c712c27d75d59 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Mon, 1 May 2023 23:27:52 -0400
+Subject: [PATCH] Drop -Werror=array-bounds
+
+gcc has strange issues with this and produces false
+positives that recently started breaking the build of
+pango as a subproject in gtk.
+
+See e.g. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+---
+ meson.build | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 930f4108..2d30c014 100644
+--- a/meson.build
++++ b/meson.build
+@@ -89,7 +89,6 @@ elif cc.get_id() == 'gcc' or cc.get_id() == 'clang'
+     '-Wuninitialized',
+     '-Wunused',
+     '-Werror=address',
+-    '-Werror=array-bounds',
+     '-Werror=empty-body',
+     '-Werror=implicit',
+     '-Werror=implicit-fallthrough',
+@@ -132,7 +131,6 @@ elif cc.get_id() == 'gcc' or cc.get_id() == 'clang'
+     '-Werror=sequence-point',
+     '-Werror=return-type',
+     '-Werror=trigraphs',
+-    '-Werror=array-bounds',
+     '-Werror=write-strings',
+     '-Werror=address',
+     '-Werror=int-to-pointer-cast',
+-- 
+2.39.2
+

--- a/meta/recipes-graphics/pango/pango_1.50.14.bb
+++ b/meta/recipes-graphics/pango/pango_1.50.14.bb
@@ -22,6 +22,7 @@ GIR_MESON_DISABLE_FLAG = "disabled"
 
 SRC_URI += "file://run-ptest \
            file://0001-Skip-running-test-layout-test.patch \
+           file://0001-Drop-Werror-array-bounds.patch \
            "
 
 SRC_URI[archive.sha256sum] = "1d67f205bfc318c27a29cfdfb6828568df566795df0cb51d2189cde7f2d581e8"


### PR DESCRIPTION
Apply Backport patch:
https://github.com/GNOME/pango/commit/e93dbd66973040f1e0afcba0dc7c712c27d75d59

To fix:

|     inlined from 'pango_language_get_scripts' at ../pango-1.50.14/pango/pango-language.c:661:21:
| ../pango-1.50.14/pango/pango-language.c:518:12: error: array subscript 0 is outside array bounds of 'const void *[0]' {aka 'const void *[]'} [-Werror=array-bounds=]
|   518 |     *cache = result;
|       |     ~~~~~~~^~~~~~~~