### PR TITLE
Fix duplicated line detection typo error in the oe-depends-dot script

### DIFF
--- a/scripts/oe-depends-dot
+++ b/scripts/oe-depends-dot
@@ -119,7 +119,7 @@ Reduce the .dot file packages only, no tasks:
                 if key == dep:
                     continue
                 if key in depends:
-                    if not key in depends[key]:
+                    if not dep in depends[key]:
                         depends[key].add(dep)
                     else:
                         print('WARNING: Fonud duplicated line: %s' % line)


### PR DESCRIPTION
"depends[key]" should store "dep", instead of the "key" itself. So it should check if dep is already in  depends[key]. 