### PR TITLE
Add scikit-build-core build backend

### DIFF
--- a/meta/classes-recipe/scikit-build-core.bbclass
+++ b/meta/classes-recipe/scikit-build-core.bbclass
@@ -1,0 +1,5 @@
+DEPENDS += "scikit-build-core-native ninja-native"
+
+inherit python_pep517 python3native python3targetconfig
+
+export PYTHONPATH="${STAGING_LIBDIR}/python-sysconfigdata"

--- a/meta/recipes-devtools/scikit-build-core/scikit-build-core_0.10.7.bb
+++ b/meta/recipes-devtools/scikit-build-core/scikit-build-core_0.10.7.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Scikit-build-core is a build backend for Python that uses CMake to build extension modules"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b4e748e5f102e31c9390dcd6fa66f09"
+
+inherit python_hatchling
+
+DEPENDS = "python3-hatch-vcs-native"
+
+SRCREV = "7636e7bd59fc7ac671905eadf3ad605bebba8a87"
+
+SRC_URI = "git://github.com/scikit-build/scikit-build-core.git;branch=main;protocol=https"
+
+S = "${WORKDIR}/git"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
https://github.com/scikit-build/scikit-build-core

Build system for e.g. Rapidfuzz.
https://github.com/rapidfuzz/RapidFuzz

Set PYTHONPATH for python3targetconfig bbclass to fix compile error Rapifuzz:

Log data follows:
| DEBUG: Executing shell function do_compile
| * Getting build dependencies for wheel...
|
| ERROR Missing dependencies:
| 	cmake>=3.15
| WARNING: exit code 1 from a shell command.

Introduced with commit:
https://github.com/openembedded/openembedded-core/commit/2442ab92f8610784d28d8d83056b643bd95b0b4e