### PR TITLE
clear warning for bootparam_root not be defined in nfsrootfs

### DIFF
--- a/meta/recipes-core/initrdscripts/initramfs-framework/nfsrootfs
+++ b/meta/recipes-core/initrdscripts/initramfs-framework/nfsrootfs
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 nfsrootfs_enabled() {
-	if [ ${bootparam_root} != "/dev/nfs" ] || [ -z ${bootparam_nfsroot} ]; then
+	if [ -z ${bootparam_root} ] || [ ${bootparam_root} != "/dev/nfs" ] || [ -z ${bootparam_nfsroot} ]; then
 		return 1
 	fi
 	return 0


### PR DESCRIPTION
In our case, there is some situation that bootparam_root is not defined

check whether bootparam_root is defined or not when running nfsrootfs