### PR TITLE
cargo_common.bbclass: Support git repos with submodules

### DIFF
--- a/meta/classes-recipe/cargo_common.bbclass
+++ b/meta/classes-recipe/cargo_common.bbclass
@@ -142,7 +142,7 @@ python cargo_common_do_patch_paths() {
     fetcher = bb.fetch2.Fetch(src_uri, d)
     for url in fetcher.urls:
         ud = fetcher.ud[url]
-        if ud.type == 'git':
+        if ud.type == 'git' or ud.type == 'gitsm':
             name = ud.parm.get('name')
             destsuffix = ud.parm.get('destsuffix')
             if name is not None and destsuffix is not None:


### PR DESCRIPTION
This is useful for cargo dependencies specified as git repositories, where those repositories themselves have submodules that need to be checked out.

(cherry picked from commit f871d9d6094ec0001d826e4b5b3395c1842631bb)