### PR TITLE
Remove warning from relocate_sdk.py

### DIFF
--- a/scripts/relocate_sdk.py
+++ b/scripts/relocate_sdk.py
@@ -27,7 +27,7 @@ else:
     def b(x):
         return x.encode(sys.getfilesystemencoding())
 
-old_prefix = re.compile(b("##DEFAULT_INSTALL_DIR##"))
+old_prefix = re.compile(rb("##DEFAULT_INSTALL_DIR##"))
 
 def get_arch():
     global endian_prefix


### PR DESCRIPTION
During installation, there is a warning.

**relocate_sdk.py:30: SyntaxWarning: invalid escape sequence '\.'**

This fix removes the warning and there is no change in functionality.